### PR TITLE
ci: Adopt GitHub workflow for Apache

### DIFF
--- a/.github/workflows/syncVersion.yml
+++ b/.github/workflows/syncVersion.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 */8 * * *"
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -15,14 +18,10 @@ jobs:
       - name: "🔄 Sync Latest Version"
         uses: ./.github/actions/sync-latest-version
       - name: "✨ Create Pull Request"
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GH_TOKEN }}
-          committer: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
-          author: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
-          commit-message: Update Metadata
-          title: 'Update Plugins JSON Metadata'
-          body: Upgrade latestVersion/coordinates of the plugins
+          commit-message: Update Plugins Metadata File
+          title: 'Update Plugins Metadata'
+          body: Update versions/coordinates of plugins.
           labels: "type: update-latest-version"
-          base: ${{ env.githubBranch }}
           branch: updateLatestVersion


### PR DESCRIPTION
There is no `grails-build` user anymore so this commit tests if it works with the built-in `github-actions[bot]` user.